### PR TITLE
Adding link checker on commit

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,0 +1,18 @@
+name: Links (Fail Fast)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.4.1
+        with:
+          fail: false
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Gitbook works by creating a "change request" in the gitbook frontend. In the back, when the change request is merged it seems to be just a simple commit to github. 

I'm adding a link checker that is triggered on commit. The `fail` flag is set to false as there are many broken links due to content pointing to Kovan. I don't want to delete the link or point to goerli cuz all the content is still talking about kovan. Also there are broken images which if I delete I lose the section that require an image (which I want to fix at some point). so for now, I just want to see that there are no new broken links, but allow gitbook to commit without any problem.